### PR TITLE
fix bug when using custom User model

### DIFF
--- a/src/Config/blogetc.php
+++ b/src/Config/blogetc.php
@@ -173,5 +173,7 @@ return [
         'search_enabled' => false, // is search enabled? By default this is disabled, but you can easily turn it on.
     ],
 
+    'user_model'=>\App\User::class,
+
 
 ];

--- a/src/Models/BlogEtcPost.php
+++ b/src/Models/BlogEtcPost.php
@@ -2,7 +2,6 @@
 
 namespace WebDevEtc\BlogEtc\Models;
 
-use App\User;
 use Cviebrock\EloquentSluggable\Sluggable;
 use Illuminate\Database\Eloquent\Model;
 use Swis\LaravelFulltext\Indexable;
@@ -99,7 +98,7 @@ class BlogEtcPost extends Model implements SearchResultInterface
      */
     public function author()
     {
-        return $this->belongsTo(User::class, 'user_id');
+        return $this->belongsTo(config("blogetc.user_model"), 'user_id');
     }
 
     /**


### PR DESCRIPTION
When using a custom User model and logged in, author cannot view blogs using the public-facing url because the post author's `belongsTo()` relationship will be referencing the wrong `User` model.

This PR fixes this bug