### PR TITLE
feat: remove swisnl/laravel-fulltext / full text searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This is [WebDevEtc's](https://webdevetc.com/) [BlogEtc Blog package for Laravel]
     - View all posts in category (paginated)
     - View single post
     - Add comment views / confirmation views
-    - Search (full text search), search form, search results page.
+    - Search, search form, search results page.
   - Admin pages:
     - Posts **(CRUD Blog Posts, Upload Featured Images (auto resizes)**
       - View all posts,
@@ -122,4 +122,12 @@ php artisan ui vue --auth;
 
 ## Issues, support, bug reports, security issues
 
-Please contact me on the contact from on [WebDev Etc](https://webdevetc.com/) or on [twitter](https://twitter.com/web_dev_etc/) and I'll get back to you asap.
+Please contact me on the contact from on [WebDev Etc](https://webdevetc.com/) or on [twitter](https://twitter.com/web_dev_etc/) and I'll get back to you ASAP.
+
+## Versions
+
+- **8.3** (Sept 2020): Removed support for `swisnl/laravel-fulltext` as it seems abandoned. 
+  - Searching in blogetc is now much more simple - it is all inline in the controller and does a simple LIKE query. 
+  - If you need full text search then I recommend you implement your own search controller (see older commits to copy code that used full text search)
+- **8.2** (Sept 2020): Added fix for dynamic title
+- **< 8.1** Support for PHP 7.2, 7.3, 7.4. Support for Lavavel 5.8.35 - 7.6

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     }
   ],
   "require": {
-    "swisnl/laravel-fulltext": "~0.19.0",
     "intervention/image": "2.*",
     "cviebrock/eloquent-sluggable": "~7.0|~6.0|~4.8|~4.7|~4.6|~4.5",
     "laravel/framework": "~5.8|~6.0|~7.0",

--- a/src/BlogEtcServiceProvider.php
+++ b/src/BlogEtcServiceProvider.php
@@ -4,10 +4,7 @@ namespace WebDevEtc\BlogEtc;
 
 use Gate;
 use Illuminate\Support\ServiceProvider;
-use Swis\Laravel\Fulltext\ModelObserver;
 use WebDevEtc\BlogEtc\Gates\GateTypes;
-use WebDevEtc\BlogEtc\Models\BlogEtcPost; // Do not remove - disable syncing for legacy class.
-use WebDevEtc\BlogEtc\Models\Post;
 
 class BlogEtcServiceProvider extends ServiceProvider
 {
@@ -18,12 +15,6 @@ class BlogEtcServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if (!config('blogetc.search.search_enabled')) {
-            ModelObserver::disableSyncingFor(Post::class);
-            // Do not remove legacy BlogEtcPost here:
-            ModelObserver::disableSyncingFor(BlogEtcPost::class);
-        }
-
         if (config('blogetc.include_default_routes', true)) {
             include __DIR__.'/routes.php';
         }

--- a/src/Controllers/PostsController.php
+++ b/src/Controllers/PostsController.php
@@ -55,7 +55,7 @@ class PostsController extends Controller
             return new class($post) {
                 public $indexable;
 
-                function __construct(Post $post)
+                public function __construct(Post $post)
                 {
                     $this->indexable = $post;
                 }
@@ -63,7 +63,7 @@ class PostsController extends Controller
         });
 
         return view('blogetc::search', [
-            'title' => 'Search results for ' . e($request->searchQuery()),
+            'title' => 'Search results for '.e($request->searchQuery()),
             'query' => $request->searchQuery(),
             'search_results' => $searchResultsMappedWithIndexable,
         ]);
@@ -110,7 +110,7 @@ class PostsController extends Controller
             $categoryID = $category->id;
 
             // TODO - make configurable
-            $title = config('blogetc.blog_index_category_title', 'Viewing blog posts in ') . $category->category_name;
+            $title = config('blogetc.blog_index_category_title', 'Viewing blog posts in ').$category->category_name;
         }
 
         $posts = $this->postsService->indexPaginated(config('blogetc.per_page'), $categoryID);

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -12,7 +12,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use RuntimeException;
-use Swis\Laravel\Fulltext\Indexable;
 use WebDevEtc\BlogEtc\Interfaces\SearchResultInterface;
 use WebDevEtc\BlogEtc\Scopes\BlogEtcPublishedScope;
 
@@ -22,7 +21,6 @@ use WebDevEtc\BlogEtc\Scopes\BlogEtcPublishedScope;
 class Post extends Model implements SearchResultInterface
 {
     use Sluggable;
-    use Indexable;
 
     /**
      * @var array
@@ -53,19 +51,6 @@ class Post extends Model implements SearchResultInterface
         'posted_at',
     ];
 
-    protected $indexContentColumns =
-        [
-            'post_body',
-            'short_description',
-            'meta_desc',
-        ];
-
-    protected $indexTitleColumns =
-        [
-            'title',
-            'subtitle',
-            'seo_title',
-        ];
     protected $table = 'blog_etc_posts';
 
     protected static function boot()
@@ -97,6 +82,9 @@ class Post extends Model implements SearchResultInterface
         ];
     }
 
+    /**
+     * @deprecated
+     */
     public function search_result_page_url()
     {
         return $this->url();

--- a/tests/Feature/Controllers/PostsControllerTest.php
+++ b/tests/Feature/Controllers/PostsControllerTest.php
@@ -64,6 +64,29 @@ class PostsControllerTest extends TestCase
         $response->assertOk()->assertViewHas('posts');
     }
 
+    public function testSearch(): void
+    {
+        $post1 = factory(Post::class)->create(['title' => 'test qwerty test']);
+        $post2 = factory(Post::class)->create(['title' => 'do not find me zxcvb']);
+
+        config(['blogetc.search.search_enabled'=>true]);
+        $response = $this->get(route('blogetc.search').'?s=qwerty');
+
+        $response->assertOk()->assertViewHas('search_results');
+
+        $response->assertSee($post1->title);
+        $response->assertDontSee($post2->title);
+    }
+
+    public function testSearchDisabled(): void
+    {
+        config(['blogetc.search.search_enabled'=>false]);
+        $response = $this->get(route('blogetc.search').'?s=test');
+
+        $response->assertForbidden();
+    }
+
+
     /**
      * Test the show page loads.
      *

--- a/tests/Feature/Controllers/PostsControllerTest.php
+++ b/tests/Feature/Controllers/PostsControllerTest.php
@@ -86,7 +86,6 @@ class PostsControllerTest extends TestCase
         $response->assertForbidden();
     }
 
-
     /**
      * Test the show page loads.
      *


### PR DESCRIPTION
 - Full text search is removed. The `swisnl/laravel-fulltext` package was not updated.
 - If you want full text search you can implement your own controller - see the changes in this commit for some ideas to copy